### PR TITLE
Fix for issue 9. Prevented src/resources/main being in the classpath for...

### DIFF
--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -81,7 +81,7 @@ buildscript {
     classpath "io.vertx:vertx-core:$vertxVersion"
     classpath "io.vertx:vertx-platform:$vertxVersion"
     // classpath "io.vertx:vertx-hazelcast:$vertxVersion"
-    classpath files(['src/main/resources'])
+    // classpath files(['src/main/resources'])
   }
 }
 


### PR DESCRIPTION
Comment out src/main/resources to fix classpath for ./gradlew runMod
