### PR TITLE
Fix javadoc warning

### DIFF
--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -42,6 +42,7 @@ project.ext.moduleName = "$modowner~$modname~$version"
 
 configurations {
   provided
+  compile.extendsFrom provided
   testCompile.extendsFrom provided
 }
 


### PR DESCRIPTION
There are several warnings when the `javadoc` task is being executed.
By making the `compile` stage extends from `provided`, the warnings disappear.
