### PR TITLE
 	#16: gradle template does not work on Windows

### DIFF
--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -86,10 +86,10 @@ buildscript {
 
     // Users can be Vert.x platform classpath files (e.g. langs.properties) in either src/main/platform_lib
     // or src/main/resources/platform_lib (if they want it in the module for fatjars)
-	  classpath files(['src/main/platform_lib'])
-	  classpath fileTree(dir: 'src/main/platform_lib', includes: ['*.jar', '*.zip'])
+    classpath files(['src/main/platform_lib'])
+    classpath fileTree(dir: 'src/main/platform_lib', includes: ['*.jar', '*.zip'])
     classpath files(['src/main/resources/platform_lib'])
-	  classpath fileTree(dir: 'src/main/resources/platform_lib', includes: ['*.jar', '*.zip'])
+    classpath fileTree(dir: 'src/main/resources/platform_lib', includes: ['*.jar', '*.zip'])
   }
 }
 


### PR DESCRIPTION
This fixes the build. Please check if files placed in the platform_lib directories are handled as you expect.
