### PR TITLE
Issue on fresh ./gradlew runMod

### DIFF
--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -168,7 +168,7 @@ task collectDeps(type: Copy) {
   }
 }
 
-task runMod(description: 'Run the module', dependsOn: collectDeps) << {
+task runMod(description: 'Run the module', dependsOn: [collectDeps, copyMod]) << {
   setSysProps()
   // We also init here - this means for single module builds the user doesn't have to explicitly init -
   // they can just do runMod


### PR DESCRIPTION
If you just clone the project and try to launch a runMod, that leads to a bad result :+1: 

```
$ ./gradlew runMod
:collectDeps
:runMod
Creating properties on demand (a.k.a. dynamic properties) has been deprecated and is scheduled to be removed in Gradle 2.0. Please read http://gradle.org/docs/current/dsl/org.gradle.api.plugins.ExtraPropertiesExtension.html for information on the replacement for dynamic properties.
Deprecated dynamic property: "args" on "task ':runMod'", value: "[runmod, com.mycompany...".
Failed in deploying module
java.lang.ClassNotFoundException: com.mycompany.myproject.PingVerticle
     at org.vertx.java.platform.impl.ModuleClassLoader.loadFromModule(ModuleClassLoader.java:122)
     at org.vertx.java.platform.impl.ModuleClassLoader.loadClass(ModuleClassLoader.java:103)
     at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
     at org.vertx.java.platform.impl.java.JavaVerticleFactory.createVerticle(JavaVerticleFactory.java:55)
     at org.vertx.java.platform.impl.DefaultPlatformManager$21.run(DefaultPlatformManager.java:1698)
     at org.vertx.java.core.impl.DefaultContext$3.run(DefaultContext.java:176)
     at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:354)
     at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:353)
     at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101)
     at java.lang.Thread.run(Thread.java:724)
Failed in deploying module
java.lang.ClassNotFoundException: com.mycompany.myproject.PingVerticle
     at org.vertx.java.platform.impl.ModuleClassLoader.loadFromModule(ModuleClassLoader.java:122)
     at org.vertx.java.platform.impl.ModuleClassLoader.loadClass(ModuleClassLoader.java:103)
     at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
     at org.vertx.java.platform.impl.java.JavaVerticleFactory.createVerticle(JavaVerticleFactory.java:55)
     at org.vertx.java.platform.impl.DefaultPlatformManager$21.run(DefaultPlatformManager.java:1698)
     at org.vertx.java.core.impl.DefaultContext$3.run(DefaultContext.java:176)
     at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:354)
     at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:353)
     at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101)
     at java.lang.Thread.run(Thread.java:724)

BUILD SUCCESSFUL
```

Adding the copyMod task as dependency to runMod tasks solve this issue.
