### PR TITLE
Fix for build/test problem with vertx-gradle-template

### DIFF
--- a/src/main/java/com/mycompany/myproject/PingVerticle.java
+++ b/src/main/java/com/mycompany/myproject/PingVerticle.java
@@ -20,7 +20,6 @@ package com.mycompany.myproject;
 
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.core.json.JsonObject;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.platform.Verticle;
 
@@ -35,13 +34,16 @@ public class PingVerticle extends Verticle {
 
     final Logger logger = container.logger();
 
+    vertx.eventBus().registerHandler("ping-address", new Handler<Message<String>>() {
+      @Override
+      public void handle(Message<String> message) {
+        message.reply("pong!");
+        logger.info("Sent back pong");
+      }
+    });
 
 
     logger.info("PingVerticle started");
-
-    JsonObject conf = new JsonObject().putString("web_root", "webroot").putNumber("port", 8080);
-
-    container.deployModule("io.vertx~mod-web-server~2.0.0-final", conf);
 
   }
 }

--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -1,5 +1,0 @@
-<html>
-<body>
-Hello world!
-</body>
-</html>


### PR DESCRIPTION
The vert.x gradle template was broken - specifically the Java PingVerticle had been amended not to deploy a listener on the event bus for "ping" messages but instead to deploy mod-webserver. This in turn caused the integration tests to fail due to timeout expecting a "pong" response (ModuleIntegrationTest in the groovy integration tests).

Furthermore the deployment of mod-webserver caused numerous "Address already in use" exceptions during the running of the unit tests. This deployment isn't tested by any test (as removing it and re-testing proved) so I wonder if the change which causes the deployment of mod-webserver was an accidental commit (the commit comment was "blah"). I've reinstated the previous version of the Java PingVerticle.
