### PR TITLE
change sonatype repository url to https to avoid redirect bug

### DIFF
--- a/src/main/platform_lib/repos.txt
+++ b/src/main/platform_lib/repos.txt
@@ -9,7 +9,7 @@ mavenLocal:~/.m2/repository
 maven:http://repo2.maven.org/maven2
 
 # Sonatype snapshots
-maven:http://oss.sonatype.org/content/repositories/snapshots
+maven:https://oss.sonatype.org/content/repositories/snapshots
 
 # Bintray
 bintray:http://dl.bintray.com


### PR DESCRIPTION
change sonatype url to https, this is the same change as the fix for 2.x branch in eclipse/vert.x

