### PR TITLE
Add link to Vert.x gradle develop guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This template also shows you how to write tests in Java, Groovy, Ruby and Python
 See the [build script](build.gradle) for the list of useful tasks
 
 ---
-See [Vert.x gradle based developer guide](﻿http://vertx.io/gradle_dev.html) on how to use this template.
+See [Vert.x gradle based developer guide](http://vertx.io/gradle_dev.html) on how to use this template.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ messages with `pong!`.
 This template also shows you how to write tests in Java, Groovy, Ruby and Python
 
 See the [build script](build.gradle) for the list of useful tasks
+
+---
+See [Vert.x gradle based developer guide](﻿http://vertx.io/gradle_dev.html) on how to use this template.


### PR DESCRIPTION
It will be useful to be able to go back to the Vert.x gradle developer guide.