### PR TITLE
fix for issue GRADLE-3101

### DIFF
--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -234,10 +234,10 @@ def loadProperties(String sourceFileName) {
 plugins.withType(IdeaPlugin) {
   idea {
     module {
-      scopes.PROVIDED.plus += configurations.provided
-      scopes.COMPILE.minus += configurations.provided
-      scopes.TEST.minus += configurations.provided
-      scopes.RUNTIME.minus += configurations.provided
+      scopes.PROVIDED.plus += [configurations.provided]
+      scopes.COMPILE.minus += [configurations.provided]
+      scopes.TEST.minus += [configurations.provided]
+      scopes.RUNTIME.minus += [configurations.provided]
     }
   }
 }


### PR DESCRIPTION
Modifications to IDEA scopes using += operator can cause dependency
resolving for configuration and the configuration cannot be changed
after that.