### PR TITLE
docs: provide answers to some common pitfalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ messages with `pong!`.
 This template also shows you how to write tests in Java, Groovy, Ruby and Python
 
 See the [build script](build.gradle) for the list of useful tasks
+
+## Common Pitfalls
+
+* Gradle command `runMod` fails to find classpath:
+    * Check if you the `VERTX_MODS` environment variable set. If so, unset it by running gradle wrapper like so instead `env -u VERTX_MODS ./gradlew runMod`.
+
+* Building JRuby verticle fails with `org.vertx.java.core.VertxException: org.jruby.embed.EvalFailedException: (Errno::ENOENT) <some/directory>`:
+    * Manually create `<some/folder>` and run task again.
+
+* Running JRuby verticle fails with `LoadError: no such file to load -- rubygems`:
+    * Try setting `RUBYOPT` environment variable, e.g. `export RUBYOPT=rubygems && ./gradlew runMod` or [see discussion on StackOverflow](http://stackoverflow.com/questions/9848830/should-jruby-complete-jar-come-with-rubygems).


### PR DESCRIPTION
Provide answers to three very common problems that can occur when using the vert.x-gradle-template, which can save a lot of time for people trying to get their feet wet with developing vert.x modules.

Btw: I signed the Eclipse CLA (User: madler6j2).
